### PR TITLE
Update docsify-auto-sidebar.ts to ignore _navbar and _coverpage

### DIFF
--- a/src/docsify-auto-sidebar.ts
+++ b/src/docsify-auto-sidebar.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as yargs from 'yargs';
 
-let ignores = /node_modules|^\.|_sidebar|_docsify/;
+let ignores = /node_modules|^\.|_sidebar|_navbar|_coverpage|_docsify/;
 let isDoc = /.md$/;
 
 type Entry = {


### PR DESCRIPTION
as it currently stands it will capture _navbar.md and _coverpage.md in the sidebar which is not ideal